### PR TITLE
Add AUR update check script

### DIFF
--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -27,6 +27,7 @@ gitcheck() {
 
         echo "Checking updates for ${package} (Installed: ${version})"
         fetch_metadata
+        check_sources
         echo
 
     done <<< "$(pacaur -Qm)"
@@ -35,6 +36,18 @@ gitcheck() {
 fetch_metadata() {
     echo "Fetching package SRCINFO..."
     curl -so "${package}.PKGBUILD" "https://aur.archlinux.org/cgit/aur.git/plain/.SRCINFO?h=${package}"
+}
+
+check_sources() {
+    local src branch
+
+    echo "Checking sources..."
+    read -r src branch <<< "$(grep -m 1 'source = ' "${package}.PKGBUILD" | parse_ghurl)"
+    echo "Found: ${src} (Branch: ${branch:-default})"
+}
+
+parse_ghurl() {
+    sed -e 's/.*github.com\/\(.*\)\.git\?\(#branch=\(.*\)\)\?/\1 \3/'
 }
 
 header() {

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+main() {
+    simplecheck Repo n
+    simplecheck AUR m
+}
+
+simplecheck() {
+    header "${1} Packages"
+    pacaur -Qu "-${2}"
+    echo
+}
+
+header() {
+    echo "----------------------------------------"
+    echo " $1"
+    echo "----------------------------------------"
+}
+
+main
+
+# vi: set ff=sh

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -17,6 +17,7 @@ main() {
     packages="$(simplecheck AUR m)"
     echo "$packages"
 
+    mkdir -p ~/.cache/aurcheck-git
     header "AUR (Git) Packages"
     gitcheck | column -t -s'|'
 }
@@ -30,14 +31,13 @@ simplecheck() {
 gitcheck() {
     local package version src branch hash
 
-    mkdir -p ~/.cache/aurcheck-git
-    cd ~/.cache/aurcheck-git || return
-
     while read -r package version; do
         # Skipping already listed updates and non-git packages
         if [[ $packages == *"$package"* ]] || grep -qv '\-git$' <<< "$package"; then
             continue
         fi
+
+        cd ~/.cache/aurcheck-git || return
 
         fetch_metadata
         check_sources
@@ -47,11 +47,19 @@ gitcheck() {
 }
 
 fetch_metadata() {
-    curl -so "${package}.PKGBUILD" "https://aur.archlinux.org/cgit/aur.git/plain/.SRCINFO?h=${package}"
+    rm -rf "${package}"
+    git clone -q "https://aur.archlinux.org/${package}.git" "${package}" && cd "${package}" || exit
+
+    # shellcheck source=/usr/share/pacman/PKGBUILD-vcs.proto
+    source PKGBUILD
 }
 
 check_sources() {
-    read -r src branch <<< "$(grep -m 1 'source = ' "${package}.PKGBUILD" | parse_ghurl)"
+    src="${source[0]}"
+
+    [[ ${src} == *"#branch="* ]] && branch=${src#*#branch=} && src=${src%#branch=*}
+    src=${src#*github.com/}
+    src=${src%.git}
 
     if [ -z "$branch" ]; then
         query_default_branch
@@ -80,10 +88,6 @@ header() {
     echo "----------------------------------------"
     echo " $1"
     echo "----------------------------------------"
-}
-
-parse_ghurl() {
-    sed -e 's/.*github.com\///g' -e 's/\(\.git$\|\(\.git\)\?\#branch=\)/ /g'
 }
 
 main

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -50,8 +50,11 @@ check_package() {
 }
 
 fetch_metadata() {
-    rm -rf "${package}"
-    git clone -q "https://aur.archlinux.org/${package}.git" "${package}" && cd "${package}" || exit
+    if [ ! -d "${package}" ]; then
+        git clone -q "https://aur.archlinux.org/${package}.git" "${package}" && cd "${package}" || exit
+    else
+        cd "${package}" && git pull -q
+    fi
 
     # shellcheck source=/usr/share/pacman/PKGBUILD-vcs.proto
     source PKGBUILD
@@ -69,7 +72,11 @@ fetch_sources() {
     [ -z "$target" ] && target=$(basename "$src")
     [ -n "$branch" ] && args=(--branch "${branch}")
 
-    git clone -q --bare "${args[@]}" "https://github.com/${src}" "${target}"
+    if [ ! -d "${target}" ]; then
+        git clone -q --bare "${args[@]}" "https://github.com/${src}" "${target}"
+    else
+        cd "${target}" && git fetch -q && cd ..
+    fi
 }
 
 pkg_status() {

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -13,7 +13,9 @@ readonly white=$'\e[37m'
 
 main() {
     simplecheck Repo n
-    simplecheck AUR m
+
+    packages="$(simplecheck AUR m)"
+    echo "$packages"
 
     header "AUR (Git) Packages"
     gitcheck | column -t -s'|'
@@ -28,12 +30,12 @@ simplecheck() {
 gitcheck() {
     local package version src branch hash
 
-    mkdir -p /tmp/aurcheck-git
-    cd /tmp/aurcheck-git
+    mkdir -p ~/.cache/aurcheck-git
+    cd ~/.cache/aurcheck-git || return
 
     while read -r package version; do
-        if grep -qv '\-git$' <<< "$package"; then
-            # Skipping -git package
+        # Skipping already listed updates and non-git packages
+        if [[ $packages == *"$package"* ]] || grep -qv '\-git$' <<< "$package"; then
             continue
         fi
 
@@ -52,8 +54,16 @@ check_sources() {
     read -r src branch <<< "$(grep -m 1 'source = ' "${package}.PKGBUILD" | parse_ghurl)"
 
     if [ -z "$branch" ]; then
-        branch=$(curl -s "${GH_API}/repos/${src}" | jq -r .default_branch)
+        query_default_branch
     fi
+}
+
+query_default_branch() {
+    if [ ! -f "${package}.branch" ]; then
+        curl -s "${GH_API}/repos/${src}" | jq -r .default_branch > "${package}.branch"
+    fi
+
+    branch=$(<"${package}.branch")
 }
 
 find_latest_commit() {

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -13,7 +13,7 @@ simplecheck() {
 }
 
 gitcheck() {
-    local package version
+    local package version src branch
 
     header "AUR (Git) Packages"
     mkdir -p /tmp/aurcheck-git
@@ -27,9 +27,13 @@ gitcheck() {
 
         echo "Checking updates for ${package} (Installed: ${version})"
         fetch_metadata
-        check_sources
-        echo
+        if check_sources; then
+            echo -e "Skipping commit check, no branch defined.\n"
+            continue
+        fi
 
+        find_latest_commit
+        echo
     done <<< "$(pacaur -Qm)"
 }
 
@@ -39,21 +43,27 @@ fetch_metadata() {
 }
 
 check_sources() {
-    local src branch
-
-    echo "Checking sources..."
+    echo -n "Checking sources... "
     read -r src branch <<< "$(grep -m 1 'source = ' "${package}.PKGBUILD" | parse_ghurl)"
-    echo "Found: ${src} (Branch: ${branch:-default})"
+    echo "Found Github repo: ${src} (Branch: ${branch:-unset})"
+
+    [ -z "$branch" ]
 }
 
-parse_ghurl() {
-    sed -e 's/.*github.com\///g' -e 's/\(\.git$\|\(\.git\)\?\#branch=\)/ /g'
+find_latest_commit() {
+    echo -n "Checking for latest commit... "
+    hash=$(curl -s "https://api.github.com/repos/${src}/git/refs/heads/${branch}" | jq -r '.object.sha')
+    echo "Found ${hash:0:8}"
 }
 
 header() {
     echo "----------------------------------------"
     echo " $1"
     echo "----------------------------------------"
+}
+
+parse_ghurl() {
+    sed -e 's/.*github.com\///g' -e 's/\(\.git$\|\(\.git\)\?\#branch=\)/ /g'
 }
 
 main

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -43,11 +43,12 @@ gitcheck() {
 }
 
 check_package() {
-    local src branch hash
+    local src branch hash target srcdir="$HOME/.cache/aurcheck-git/${package}"
 
     fetch_metadata
-    check_sources
+    fetch_sources
     find_latest_commit
+    update="$(pkgver)"
     pkg_status
 }
 
@@ -59,16 +60,18 @@ fetch_metadata() {
     source PKGBUILD
 }
 
-check_sources() {
+fetch_sources() {
     src="${source[0]}"
 
     [[ ${src} == *"#branch="* ]] && branch=${src#*#branch=} && src=${src%#branch=*}
+    [[ ${src} == *"::"* ]] && target="${src%::*}"
     src=${src#*github.com/}
     src=${src%.git}
 
-    if [ -z "$branch" ]; then
-        query_default_branch
-    fi
+    [ -z "$target" ] && target=$(basename "$src")
+    [ -z "$branch" ] && query_default_branch
+
+    git clone -q --bare --branch "${branch}" "https://github.com/${src}" "${target}"
 }
 
 query_default_branch() {
@@ -86,7 +89,7 @@ find_latest_commit() {
 pkg_status() {
     echo -en "${bold}${cyan}:: ${magenta}aur-git|${white}${package} "
     echo -en "(${yellow}${src}${white}@${cyan}${branch}${white})|"
-    echo -e "${red}${version}${reset}|->|${bold}${green}${hash:0:8}${reset}"
+    echo -e "${red}${version}${reset}|->|${bold}${green}${update}|${hash:0:8}${reset}"
 }
 
 header() {

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -16,6 +16,8 @@ gitcheck() {
     local package version
 
     header "AUR (Git) Packages"
+    mkdir -p /tmp/aurcheck-git
+    cd /tmp/aurcheck-git
 
     while read -r package version; do
         if grep -qv '\-git$' <<< "$package"; then
@@ -23,8 +25,16 @@ gitcheck() {
             continue
         fi
 
-        echo "${package} (Installed: ${version})"
+        echo "Checking updates for ${package} (Installed: ${version})"
+        fetch_metadata
+        echo
+
     done <<< "$(pacaur -Qm)"
+}
+
+fetch_metadata() {
+    echo "Fetching package SRCINFO..."
+    curl -so "${package}.PKGBUILD" "https://aur.archlinux.org/cgit/aur.git/plain/.SRCINFO?h=${package}"
 }
 
 header() {

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -29,7 +29,7 @@ simplecheck() {
 }
 
 gitcheck() {
-    local package version src branch hash
+    local package version
 
     while read -r package version; do
         # Skipping already listed updates and non-git packages
@@ -38,12 +38,17 @@ gitcheck() {
         fi
 
         cd ~/.cache/aurcheck-git || return
-
-        fetch_metadata
-        check_sources
-        find_latest_commit
-        pkg_status
+        check_package
     done <<< "$(pacaur -Qm)"
+}
+
+check_package() {
+    local src branch hash
+
+    fetch_metadata
+    check_sources
+    find_latest_commit
+    pkg_status
 }
 
 fetch_metadata() {

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -2,6 +2,14 @@
 
 readonly GH_API="https://api.github.com"
 
+readonly bold=$(tput bold)
+readonly reset=$'\e[0m'
+readonly red=$'\e[31m'
+readonly green=$'\e[32m'
+readonly blue=$'\e[34m'
+readonly magenta=$'\e[35m'
+readonly white=$'\e[37m'
+
 main() {
     simplecheck Repo n
     simplecheck AUR m
@@ -15,7 +23,7 @@ simplecheck() {
 }
 
 gitcheck() {
-    local package version src branch
+    local package version src branch hash
 
     header "AUR (Git) Packages"
     mkdir -p /tmp/aurcheck-git
@@ -27,34 +35,32 @@ gitcheck() {
             continue
         fi
 
-        echo "Checking updates for ${package} (Installed: ${version})"
         fetch_metadata
         check_sources
         find_latest_commit
-        echo
+        pkg_status
     done <<< "$(pacaur -Qm)"
 }
 
 fetch_metadata() {
-    echo "Fetching package SRCINFO..."
     curl -so "${package}.PKGBUILD" "https://aur.archlinux.org/cgit/aur.git/plain/.SRCINFO?h=${package}"
 }
 
 check_sources() {
-    echo -n "Checking sources... "
     read -r src branch <<< "$(grep -m 1 'source = ' "${package}.PKGBUILD" | parse_ghurl)"
 
     if [ -z "$branch" ]; then
         branch=$(curl -s "${GH_API}/repos/${src}" | jq -r .default_branch)
     fi
-
-    echo "Found Github repo: ${src} (Branch: ${branch:-unset})"
 }
 
 find_latest_commit() {
-    echo -n "Checking for latest commit... "
     hash=$(curl -s "${GH_API}/repos/${src}/git/refs/heads/${branch}" | jq -r '.object.sha')
-    echo "Found ${hash:0:8}"
+}
+
+pkg_status() {
+    echo -en "${blue}:: ${bold}${magenta}aur-git  ${white}${package} (${src}@${branch}) "
+    echo -e "${red}${version}${reset} -> ${bold}${green}${hash:0:8}${reset}"
 }
 
 header() {

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -47,7 +47,7 @@ check_sources() {
 }
 
 parse_ghurl() {
-    sed -e 's/.*github.com\/\(.*\)\.git\?\(#branch=\(.*\)\)\?/\1 \3/'
+    sed -e 's/.*github.com\///g' -e 's/\(\.git$\|\(\.git\)\?\#branch=\)/ /g'
 }
 
 header() {

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+readonly GH_API="https://api.github.com"
+
 main() {
     simplecheck Repo n
     simplecheck AUR m
@@ -27,11 +29,7 @@ gitcheck() {
 
         echo "Checking updates for ${package} (Installed: ${version})"
         fetch_metadata
-        if check_sources; then
-            echo -e "Skipping commit check, no branch defined.\n"
-            continue
-        fi
-
+        check_sources
         find_latest_commit
         echo
     done <<< "$(pacaur -Qm)"
@@ -45,14 +43,17 @@ fetch_metadata() {
 check_sources() {
     echo -n "Checking sources... "
     read -r src branch <<< "$(grep -m 1 'source = ' "${package}.PKGBUILD" | parse_ghurl)"
-    echo "Found Github repo: ${src} (Branch: ${branch:-unset})"
 
-    [ -z "$branch" ]
+    if [ -z "$branch" ]; then
+        branch=$(curl -s "${GH_API}/repos/${src}" | jq -r .default_branch)
+    fi
+
+    echo "Found Github repo: ${src} (Branch: ${branch:-unset})"
 }
 
 find_latest_commit() {
     echo -n "Checking for latest commit... "
-    hash=$(curl -s "https://api.github.com/repos/${src}/git/refs/heads/${branch}" | jq -r '.object.sha')
+    hash=$(curl -s "${GH_API}/repos/${src}/git/refs/heads/${branch}" | jq -r '.object.sha')
     echo "Found ${hash:0:8}"
 }
 

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -10,20 +10,14 @@ readonly cyan=$'\e[36m'
 readonly white=$'\e[37m'
 
 main() {
-    simplecheck Repo n
+    pacaur -Qun
+    echo
 
-    packages="$(simplecheck AUR m)"
+    packages="$(pacaur -Qum)"
     echo -e "$packages\n"
 
     mkdir -p ~/.cache/aurcheck-git
-    header "AUR (Git) Packages"
     gitcheck | column -t -s'|'
-}
-
-simplecheck() {
-    header "${1} Packages"
-    pacaur -Qu "-${2}"
-    echo
 }
 
 gitcheck() {
@@ -41,7 +35,7 @@ gitcheck() {
 }
 
 check_package() {
-    local src branch srcdir="${HOME}/.cache/aurcheck-git/${package}"
+    local update srcdir="${HOME}/.cache/aurcheck-git/${package}"
 
     fetch_metadata
     fetch_sources
@@ -61,8 +55,7 @@ fetch_metadata() {
 }
 
 fetch_sources() {
-    local target args=()
-    src="${source[0]}"
+    local target branch args=() src="${source[0]}"
 
     [[ ${src} == *"#branch="* ]] && branch=${src#*#branch=} && src=${src%#branch=*}
     [[ ${src} == *"::"* ]] && target="${src%::*}"
@@ -81,14 +74,7 @@ fetch_sources() {
 
 pkg_status() {
     echo -en "${bold}${cyan}:: ${magenta}aur-git|${white}${package} "
-    echo -en "(${yellow}${src}${white}@${cyan}${branch}${white})|"
     echo -e "${red}${version}${reset}|->|${bold}${green}${update}${reset}"
-}
-
-header() {
-    echo "----------------------------------------"
-    echo " $1"
-    echo "----------------------------------------"
 }
 
 main

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -15,7 +15,7 @@ main() {
     simplecheck Repo n
 
     packages="$(simplecheck AUR m)"
-    echo "$packages"
+    echo -e "$packages\n"
 
     mkdir -p ~/.cache/aurcheck-git
     header "AUR (Git) Packages"

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -6,14 +6,17 @@ readonly bold=$(tput bold)
 readonly reset=$'\e[0m'
 readonly red=$'\e[31m'
 readonly green=$'\e[32m'
-readonly blue=$'\e[34m'
+readonly yellow=$'\e[33m'
 readonly magenta=$'\e[35m'
+readonly cyan=$'\e[36m'
 readonly white=$'\e[37m'
 
 main() {
     simplecheck Repo n
     simplecheck AUR m
-    gitcheck
+
+    header "AUR (Git) Packages"
+    gitcheck | column -t -s'|'
 }
 
 simplecheck() {
@@ -25,7 +28,6 @@ simplecheck() {
 gitcheck() {
     local package version src branch hash
 
-    header "AUR (Git) Packages"
     mkdir -p /tmp/aurcheck-git
     cd /tmp/aurcheck-git
 
@@ -59,8 +61,9 @@ find_latest_commit() {
 }
 
 pkg_status() {
-    echo -en "${blue}:: ${bold}${magenta}aur-git  ${white}${package} (${src}@${branch}) "
-    echo -e "${red}${version}${reset} -> ${bold}${green}${hash:0:8}${reset}"
+    echo -en "${bold}${cyan}:: ${magenta}aur-git|${white}${package} "
+    echo -en "(${yellow}${src}${white}@${cyan}${branch}${white})|"
+    echo -e "${red}${version}${reset}|->|${bold}${green}${hash:0:8}${reset}"
 }
 
 header() {

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -3,12 +3,28 @@
 main() {
     simplecheck Repo n
     simplecheck AUR m
+    gitcheck
 }
 
 simplecheck() {
     header "${1} Packages"
     pacaur -Qu "-${2}"
     echo
+}
+
+gitcheck() {
+    local package version
+
+    header "AUR (Git) Packages"
+
+    while read -r package version; do
+        if grep -qv '\-git$' <<< "$package"; then
+            # Skipping -git package
+            continue
+        fi
+
+        echo "${package} (Installed: ${version})"
+    done <<< "$(pacaur -Qm)"
 }
 
 header() {

--- a/stowable/scripts/checkupdates
+++ b/stowable/scripts/checkupdates
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-readonly GH_API="https://api.github.com"
-
 readonly bold=$(tput bold)
 readonly reset=$'\e[0m'
 readonly red=$'\e[31m'
@@ -43,11 +41,10 @@ gitcheck() {
 }
 
 check_package() {
-    local src branch hash target srcdir="$HOME/.cache/aurcheck-git/${package}"
+    local src branch srcdir="${HOME}/.cache/aurcheck-git/${package}"
 
     fetch_metadata
     fetch_sources
-    find_latest_commit
     update="$(pkgver)"
     pkg_status
 }
@@ -61,6 +58,7 @@ fetch_metadata() {
 }
 
 fetch_sources() {
+    local target args=()
     src="${source[0]}"
 
     [[ ${src} == *"#branch="* ]] && branch=${src#*#branch=} && src=${src%#branch=*}
@@ -69,27 +67,15 @@ fetch_sources() {
     src=${src%.git}
 
     [ -z "$target" ] && target=$(basename "$src")
-    [ -z "$branch" ] && query_default_branch
+    [ -n "$branch" ] && args=(--branch "${branch}")
 
-    git clone -q --bare --branch "${branch}" "https://github.com/${src}" "${target}"
-}
-
-query_default_branch() {
-    if [ ! -f "${package}.branch" ]; then
-        curl -s "${GH_API}/repos/${src}" | jq -r .default_branch > "${package}.branch"
-    fi
-
-    branch=$(<"${package}.branch")
-}
-
-find_latest_commit() {
-    hash=$(curl -s "${GH_API}/repos/${src}/git/refs/heads/${branch}" | jq -r '.object.sha')
+    git clone -q --bare "${args[@]}" "https://github.com/${src}" "${target}"
 }
 
 pkg_status() {
     echo -en "${bold}${cyan}:: ${magenta}aur-git|${white}${package} "
     echo -en "(${yellow}${src}${white}@${cyan}${branch}${white})|"
-    echo -e "${red}${version}${reset}|->|${bold}${green}${update}|${hash:0:8}${reset}"
+    echo -e "${red}${version}${reset}|->|${bold}${green}${update}${reset}"
 }
 
 header() {
@@ -99,5 +85,3 @@ header() {
 }
 
 main
-
-# vi: set ff=sh


### PR DESCRIPTION
Lists updates for the main Arch repos and AUR packages using `pacaur -Qu{n,m}` with an additional list below that shows updates for all `-git` packages installed from AUR that aren't already shown in the main AUR list.

Works by cloning the AUR package repo, parsing the first `source` value for `user/repo`, branch etc and clones a `--bare` copy of the source repository in which it runs the `pkgver()` function from the `PKGBUILD` to get the "real" latest version number.

Often `-git` packages don't get updated so some packages can be left stale for a number of years unless you're in the habit of manually reinstalling every `-git` package regularly. This script solves that issue so you always know what packages have updates available.

*To do: Pacaur already keeps a copy of AUR/source repos. Could probably save a few megs of space by using it instead of maintaining our own cache in `~/.cache/aurcheck-git`.*

![image](https://user-images.githubusercontent.com/1521802/55565952-b3324000-56f2-11e9-8152-58a9b96b6c9b.png)
